### PR TITLE
break out of while loops to prevent hanging indefinitely

### DIFF
--- a/Adafruit_AHTX0.cpp
+++ b/Adafruit_AHTX0.cpp
@@ -87,8 +87,13 @@ bool Adafruit_AHTX0::begin(TwoWire *wire, int32_t sensor_id) {
     return false;
   }
 
-  while (getStatus() & AHTX0_STATUS_BUSY) {
+  uint8_t count = 0;
+  while ((getStatus() & AHTX0_STATUS_BUSY) && count < 10) {
     delay(10);
+    count++;
+  }
+  if(count == 10) {
+    return false;
   }
   if (!(getStatus() & AHTX0_STATUS_CALIBRATED)) {
     return false;
@@ -131,8 +136,13 @@ bool Adafruit_AHTX0::getEvent(sensors_event_t *humidity,
     return false;
   }
 
-  while (getStatus() & AHTX0_STATUS_BUSY) {
+  uint8_t count = 0;
+  while ((getStatus() & AHTX0_STATUS_BUSY) && count < 10) {
     delay(10);
+    count++;
+  }
+  if(count == 10) {
+    return false;
   }
 
   uint8_t data[6];


### PR DESCRIPTION
In some cases the library would hang indefinitely when either the `begin()` or `getEvent()` function was called. In my case this happened with a faulty connector (VDD line disconnected). This is a quick and easy fix that allows the main program to continue operation after retrying for a maximum of 10 tries. 