### PR TITLE
Add alternate address to begin()

### DIFF
--- a/Adafruit_AHTX0.cpp
+++ b/Adafruit_AHTX0.cpp
@@ -57,6 +57,8 @@ Adafruit_AHTX0::~Adafruit_AHTX0(void) {
  *            The Wire object to be used for I2C connections.
  *    @param  sensor_id
  *            The unique ID to differentiate the sensors from others
+ *    @param  i2c_address
+ *            The I2C address used to communicate with the sensor
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_AHTX0::begin(TwoWire *wire, int32_t sensor_id,

--- a/Adafruit_AHTX0.cpp
+++ b/Adafruit_AHTX0.cpp
@@ -59,7 +59,8 @@ Adafruit_AHTX0::~Adafruit_AHTX0(void) {
  *            The unique ID to differentiate the sensors from others
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_AHTX0::begin(TwoWire *wire, int32_t sensor_id, uint8_t i2c_address) {
+bool Adafruit_AHTX0::begin(TwoWire *wire, int32_t sensor_id,
+                           uint8_t i2c_address) {
   delay(20); // 20 ms to power up
 
   if (i2c_dev) {

--- a/Adafruit_AHTX0.cpp
+++ b/Adafruit_AHTX0.cpp
@@ -59,14 +59,14 @@ Adafruit_AHTX0::~Adafruit_AHTX0(void) {
  *            The unique ID to differentiate the sensors from others
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_AHTX0::begin(TwoWire *wire, int32_t sensor_id) {
+bool Adafruit_AHTX0::begin(TwoWire *wire, int32_t sensor_id, uint8_t i2c_address) {
   delay(20); // 20 ms to power up
 
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }
 
-  i2c_dev = new Adafruit_I2CDevice(AHTX0_I2CADDR_DEFAULT, wire);
+  i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 
   if (!i2c_dev->begin()) {
     return false;

--- a/Adafruit_AHTX0.h
+++ b/Adafruit_AHTX0.h
@@ -80,7 +80,8 @@ public:
   Adafruit_AHTX0();
   ~Adafruit_AHTX0();
 
-  bool begin(TwoWire *wire = &Wire, int32_t sensor_id = 0, uint8_t i2c_address = AHTX0_I2CADDR_DEFAULT);
+  bool begin(TwoWire *wire = &Wire, int32_t sensor_id = 0,
+             uint8_t i2c_address = AHTX0_I2CADDR_DEFAULT);
 
   bool getEvent(sensors_event_t *humidity, sensors_event_t *temp);
   uint8_t getStatus(void);

--- a/Adafruit_AHTX0.h
+++ b/Adafruit_AHTX0.h
@@ -25,6 +25,7 @@
 #include <Wire.h>
 
 #define AHTX0_I2CADDR_DEFAULT 0x38   ///< AHT default i2c address
+#define AHTX0_I2CADDR_ALTERNATE 0x39 ///< AHT alternate i2c address
 #define AHTX0_CMD_CALIBRATE 0xE1     ///< Calibration command
 #define AHTX0_CMD_TRIGGER 0xAC       ///< Trigger reading command
 #define AHTX0_CMD_SOFTRESET 0xBA     ///< Soft reset command
@@ -79,7 +80,7 @@ public:
   Adafruit_AHTX0();
   ~Adafruit_AHTX0();
 
-  bool begin(TwoWire *wire = &Wire, int32_t sensor_id = 0);
+  bool begin(TwoWire *wire = &Wire, int32_t sensor_id = 0, uint8_t i2c_address = AHTX0_I2CADDR_DEFAULT);
 
   bool getEvent(sensors_event_t *humidity, sensors_event_t *temp);
   uint8_t getStatus(void);


### PR DESCRIPTION
This patch adds an additional optional parameter to the begin() method, the i2c_address. This allows to switch from the default address of the sensor to the alternate address.
Fixes issue "Add alternative I2C address as parameter for the begin() method #7"