### PR TITLE
make it ticker loop()-friendlier

### DIFF
--- a/Adafruit_AHTX0.h
+++ b/Adafruit_AHTX0.h
@@ -39,7 +39,8 @@ class Adafruit_AHTX0;
  * of AHT10/AHT20
  *
  */
-class Adafruit_AHTX0_Humidity : public Adafruit_Sensor {
+class Adafruit_AHTX0_Humidity : public Adafruit_Sensor
+{
 public:
   /** @brief Create an Adafruit_Sensor compatible object for the humidity sensor
     @param parent A pointer to the AHTX0 class */
@@ -57,7 +58,8 @@ private:
  * of AHT10/AHT20
  *
  */
-class Adafruit_AHTX0_Temp : public Adafruit_Sensor {
+class Adafruit_AHTX0_Temp : public Adafruit_Sensor
+{
 public:
   /** @brief Create an Adafruit_Sensor compatible object for the temp sensor
       @param parent A pointer to the AHTX0 class */
@@ -75,7 +77,8 @@ private:
  *    @brief  Class that stores state and functions for interacting with
  *            the AHT10/AHT20 I2C Temperature/Humidity sensor
  */
-class Adafruit_AHTX0 {
+class Adafruit_AHTX0
+{
 public:
   Adafruit_AHTX0();
   ~Adafruit_AHTX0();
@@ -87,6 +90,9 @@ public:
   uint8_t getStatus(void);
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getHumiditySensor(void);
+
+  bool triggerEvent();
+  bool fetchEvent(sensors_event_t *humidity, sensors_event_t *temp);
 
 protected:
   float _temperature, ///< Last reading's temperature (C)


### PR DESCRIPTION
make it ticker loop()-friendlier
* split getEvent() into two parts (triggerEvent() and fetchEvent()) so they can be called in a ticker-loop. 
* this removes the "delay(10)" and i2c polling
* getEvent() stays compatible

concept:
```
void loopSensor() {
  const uint32_t wartezeit = 1000l;  // 1 second
  static uint32_t ticker = -wartezeit;
  static triggermeasurement = true;

  if (millis() - ticker > wartezeit) {
    if (triggermeasurement) {
      aht21.triggerEvent();
    } else {
      sensors_event_t humidity, temp;
      if (aht21.fetchEvent(&humidity, &temp)) {
        //... process
      }
    }
    triggermeasurement=!triggermeasurement;
    ticker = millis();
  }
}
```